### PR TITLE
add requests in requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
 import sys, os
 
-VERSION = '0.0.2'
+VERSION = '0.0.3'
 
 REQUIRES = [
-    'nose',
+    'nose', 'requests',
 ]
 
 setup(name='libvin',


### PR DESCRIPTION
Fix bug : 
File "/usr/local/lib/python3.6/site-packages/libvin/nhtsa.py", line 9, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'